### PR TITLE
fix: :art: changed onclose to onClose

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1069,7 +1069,7 @@ function App() {
               <RavenButton
                 className='btn-outline-white-light success_btn'
                 onClick={() => {
-                  postMessage('onclose', 'transaction_success', config), navigate(callbackUrl)
+                  postMessage('onClose', 'transaction_success', config), navigate(callbackUrl)
                 }}
                 label='Close Payment'
               />
@@ -1087,7 +1087,7 @@ function App() {
           smallText={'Are you sure you want to cancel this payment request, please confirm before proceeding.'}
           btnText={'Close modal'}
           onClick={() => {
-            postMessage('onclose', 'Payment window closed'), setClosed(true), navigate(callbackUrl)
+            postMessage('onClose', 'Payment window closed'), setClosed(true), navigate(callbackUrl)
           }}
           onCancel={() => onModalCancel(false)}
         />


### PR DESCRIPTION
We were using a lower case onclose for all onclose messages whilst the convention was i.e onOpen so i changed it from the all lowercase onclose to onClose

people integrating via sdk's will have to change their onClose listener from onclose to onClose