### PR TITLE
feat: :art: Show Customer Email instead of Business Email

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -471,7 +471,7 @@ function App() {
                   <div className='header_main_container'>
                     <div className='header'>
                       <div className='header_details'>
-                        <p className='business_email'>{config?.email}</p>
+                        <p className='business_email'>{config?.customer_email || config?.email || '--'}</p>
                         <span className='payment_amount'>
                           <p>Pay</p>
                           {has_keys.length > 0 ? <h5>₦{formatNumWithCommaNaira(String(config?.amount))}</h5> : ''}


### PR DESCRIPTION
The payment window now bears the email of the customer instead of the business but in a case where by the customer_email is undefined it displays the business email and in a case where both is undefined it displays '--' as a fallback string